### PR TITLE
Initialize Flask skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+ENV/
+
+# macOS
+.DS_Store
+
+# Python packaging
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Goal: Build the core Flask server, database models, and API endpoints for managi
 
 
 
-\[ ] Task BE-01: Set up the basic Flask project structure.
+\[x] Task BE-01: Set up the basic Flask project structure.
 
 
 

--- a/src/time_profiler/__init__.py
+++ b/src/time_profiler/__init__.py
@@ -1,1 +1,5 @@
-# This file makes 'src/time_profiler' a Python package.
+"""Main package for the DCRI Activity Logging Tool."""
+
+from .app import create_app, init_db, SessionLocal, Base
+
+__all__ = ["create_app", "init_db", "SessionLocal", "Base"]

--- a/src/time_profiler/app.py
+++ b/src/time_profiler/app.py
@@ -1,0 +1,34 @@
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base, scoped_session
+
+# SQLAlchemy setup
+engine = None
+SessionLocal = scoped_session(sessionmaker())
+Base = declarative_base()
+
+
+def init_db(database_url: str):
+    """Initialize the database engine and session factory."""
+    global engine
+    engine = create_engine(database_url)
+    SessionLocal.configure(bind=engine)
+
+
+def create_app(config_object: dict | None = None) -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+
+    # Default configuration
+    app.config.setdefault("DATABASE_URL", "sqlite:///dcri_logger.db")
+
+    if config_object:
+        app.config.update(config_object)
+
+    init_db(app.config["DATABASE_URL"])
+
+    @app.route("/health")
+    def health() -> dict:
+        return {"status": "ok"}
+
+    return app

--- a/src/time_profiler/main.py
+++ b/src/time_profiler/main.py
@@ -1,0 +1,8 @@
+"""Entry point for running the Flask application."""
+
+from . import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the src directory is on the Python path for tests
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+SRC_DIR = os.path.join(ROOT_DIR, 'src')
+sys.path.insert(0, SRC_DIR)


### PR DESCRIPTION
## Summary
- create basic Flask project scaffolding with health endpoint
- expose app factory and DB helpers
- add entrypoint for running the server
- ensure tests import the package by adding `conftest.py`
- ignore bytecode
- mark BE-01 as completed in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bd66d008c832eb43bf8019a52f5da