### PR TITLE
Implement BE-04 config endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Status: Critical Path
 
 
 
-\[ ] Task BE-04: Create an API endpoint (GET /api/config) to serve the dcri\_config.json file.
+\[x] Task BE-04: Create an API endpoint (GET /api/config) to serve the dcri\_config.json file.
 
 
 

--- a/src/time_profiler/app.py
+++ b/src/time_profiler/app.py
@@ -1,4 +1,11 @@
-from flask import Flask
+"""Flask application factory and database setup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from flask import Flask, jsonify
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base, scoped_session
 
@@ -6,6 +13,12 @@ from sqlalchemy.orm import sessionmaker, declarative_base, scoped_session
 engine = None
 SessionLocal = scoped_session(sessionmaker())
 Base = declarative_base()
+
+
+def load_config(config_path: Path) -> dict:
+    """Load the DCRI configuration from a JSON file."""
+    with config_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def init_db(database_url: str):
@@ -21,11 +34,19 @@ def create_app(config_object: dict | None = None) -> Flask:
 
     # Default configuration
     app.config.setdefault("DATABASE_URL", "sqlite:///dcri_logger.db")
+    default_config_path = Path(__file__).resolve().parents[2] / "config" / "dcri_config.json.example"
+    app.config.setdefault("DCRI_CONFIG_PATH", default_config_path)
 
     if config_object:
         app.config.update(config_object)
 
     init_db(app.config["DATABASE_URL"])
+
+    @app.route("/api/config", methods=["GET"])
+    def get_config() -> jsonify:
+        """Return configuration data loaded from the JSON file."""
+        config_data = load_config(Path(app.config["DCRI_CONFIG_PATH"]))
+        return jsonify(config_data)
 
     @app.route("/health")
     def health() -> dict:

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -1,0 +1,16 @@
+import json
+from time_profiler import create_app
+
+
+def test_get_config_endpoint(tmp_path):
+    app = create_app({"TESTING": True})
+    client = app.test_client()
+
+    response = client.get("/api/config")
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert isinstance(data, dict)
+    assert "groups" in data
+    assert "activities" in data
+    assert "enableFreeTextFeedback" in data


### PR DESCRIPTION
## Summary
- expose new `/api/config` endpoint for configuration
- load config from JSON file via new helper
- update README checklist
- add unit test for `/api/config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bd882a770832e86db53fd642afcaa