### PR TITLE
Implement Alembic migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Status: Critical Path
 
 
 
-\[ ] Task BE-03: Implement Alembic for managing database migrations.
+\[x] Task BE-03: Implement Alembic for managing database migrations.
 
 
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = src/time_profiler/migrations
+sqlalchemy.url = sqlite:///dcri_logger.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/src/time_profiler/migrations/env.py
+++ b/src/time_profiler/migrations/env.py
@@ -1,0 +1,62 @@
+from __future__ import with_statement
+
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from time_profiler.app import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def get_url() -> str:
+    """Retrieve database URL from environment variable or config."""
+    return os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    configuration = config.get_section(config.config_ini_section)
+    configuration["sqlalchemy.url"] = get_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/src/time_profiler/migrations/versions/0001_create_activitylog.py
+++ b/src/time_profiler/migrations/versions/0001_create_activitylog.py
@@ -1,0 +1,31 @@
+"""create activity log table
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-01-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'activity_logs',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('group_id', sa.String(), nullable=False),
+        sa.Column('activity', sa.String(), nullable=False),
+        sa.Column('sub_activity', sa.String(), nullable=False),
+        sa.Column('feedback', sa.Text(), nullable=True),
+        sa.Column('timestamp', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('activity_logs')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from sqlalchemy import create_engine, inspect
+from alembic.config import Config
+from alembic import command
+
+
+def test_run_migrations(tmp_path):
+    """Ensure Alembic migrations run and create the activity_logs table."""
+    db_path = tmp_path / "test.db"
+    cfg = Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    inspector = inspect(engine)
+    assert "activity_logs" in inspector.get_table_names()
+


### PR DESCRIPTION
## Summary
- integrate Alembic with a new config and migration scripts
- create initial migration for ActivityLog table
- add test ensuring migrations run
- mark BE-03 complete in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bdb73969c832e932d30c26dd63e64