### PR TITLE
Implement BE-06 feedback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Status: Critical Path
 
 
 
-\[ ] Task BE-06: Implement logic in the submission endpoint to handle the optional feedback text field.
+\[x] Task BE-06: Implement logic in the submission endpoint to handle the optional feedback text field.
 
 
 

--- a/src/time_profiler/app.py
+++ b/src/time_profiler/app.py
@@ -80,10 +80,15 @@ def create_app(config_object: dict | None = None) -> Flask:
 
         session = SessionLocal()
         try:
+            feedback_text = None
+            if config.get("enableFreeTextFeedback"):
+                feedback_text = data.get("feedback")
+
             log_entry = models.ActivityLog(
                 group_id=data["group_id"],
                 activity=data["activity"],
                 sub_activity=data["sub_activity"],
+                feedback=feedback_text,
             )
             session.add(log_entry)
             session.commit()

--- a/tests/test_submit_endpoint.py
+++ b/tests/test_submit_endpoint.py
@@ -6,6 +6,7 @@ from time_profiler.app import load_config
 
 
 def setup_app(tmp_path):
+    SessionLocal.remove()
     db_url = f"sqlite:///{tmp_path}/test.db"
     app = create_app({"TESTING": True, "DATABASE_URL": db_url})
     return app
@@ -52,6 +53,64 @@ def test_submit_endpoint_invalid_group(tmp_path):
     }
     response = client.post("/api/submit", json=payload)
     assert response.status_code == 400
+
+
+def test_submit_endpoint_with_feedback(tmp_path):
+    app = setup_app(tmp_path)
+    client = app.test_client()
+
+    config = load_config(Path(app.config["DCRI_CONFIG_PATH"]))
+    if not config.get("enableFreeTextFeedback"):
+        return
+
+    group_id = config["groups"][0]["id"]
+    activity = config["activities"][0]["category"]
+    sub_activity = config["activities"][0]["sub_activities"][0]
+
+    feedback = "great work"
+    payload = {
+        "group_id": group_id,
+        "activity": activity,
+        "sub_activity": sub_activity,
+        "feedback": feedback,
+    }
+    response = client.post("/api/submit", json=payload)
+    assert response.status_code == 200
+
+    session = SessionLocal()
+    log = session.query(ActivityLog).first()
+    session.close()
+    assert log.feedback == feedback
+
+
+def test_feedback_ignored_when_disabled(tmp_path):
+    config_path = tmp_path / "config.json"
+    orig = load_config(Path(__file__).resolve().parents[1] / "config" / "dcri_config.json.example")
+    orig["enableFreeTextFeedback"] = False
+    config_path.write_text(json.dumps(orig))
+
+    SessionLocal.remove()
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    app = create_app({"TESTING": True, "DATABASE_URL": db_url, "DCRI_CONFIG_PATH": config_path})
+    client = app.test_client()
+
+    group_id = orig["groups"][0]["id"]
+    activity = orig["activities"][0]["category"]
+    sub_activity = orig["activities"][0]["sub_activities"][0]
+
+    payload = {
+        "group_id": group_id,
+        "activity": activity,
+        "sub_activity": sub_activity,
+        "feedback": "should not store",
+    }
+    response = client.post("/api/submit", json=payload)
+    assert response.status_code == 200
+
+    session = SessionLocal()
+    log = session.query(ActivityLog).first()
+    session.close()
+    assert log.feedback is None
 
 
 


### PR DESCRIPTION
## Summary
- store optional feedback text in the `/api/submit` endpoint when `enableFreeTextFeedback` is true
- add tests covering feedback handling and disabled case
- mark BE-06 complete in README

## Testing
- `python3 -m venv .venv && source .venv/bin/activate && pip install -q pytest flask sqlalchemy alembic && pytest -q && deactivate`

------
https://chatgpt.com/codex/tasks/task_b_687bdd90b72c832e8b419db12acddb36