### PR TITLE
Implement dashboard results fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Status: Critical Path
 
 
 
-\[ ] Task DB-02: Write JavaScript to fetch aggregated data from the /api/results endpoint.
+\[x] Task DB-02: Write JavaScript to fetch aggregated data from the /api/results endpoint.
 
 
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -14,7 +14,32 @@
         <h1 class="title">DCRI Activity Dashboard</h1>
         <div id="dashboard-content">
             <!-- Charts will be rendered here in future tasks -->
+            <p id="loading-message">Loading results...</p>
         </div>
     </div>
+    <script>
+        // Fetch aggregated results from the backend when the page loads
+        document.addEventListener("DOMContentLoaded", async () => {
+            const container = document.getElementById("dashboard-content");
+            try {
+                const response = await fetch("/api/results");
+                if (!response.ok) {
+                    throw new Error("Failed to load results");
+                }
+                // Store results globally for later chart rendering (DB-03)
+                window.dashboardData = await response.json();
+                console.log("Aggregated results", window.dashboardData);
+
+                // For now, simply show the raw JSON as a placeholder
+                container.innerHTML = `<pre>${JSON.stringify(window.dashboardData, null, 2)}</pre>`;
+            } catch (err) {
+                console.error("Error fetching results:", err);
+                container.textContent = "Error loading results.";
+            } finally {
+                const loadingMsg = document.getElementById("loading-message");
+                if (loadingMsg) loadingMsg.remove();
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch aggregated results on dashboard page
- display raw JSON for now
- mark DB-02 complete in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687be2492e24832e8592d84e9a0c8e8c