### PR TITLE
Implement DB-03 dashboard charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Status: Critical Path
 
 
 
-\[ ] Task DB-03: Use a charting library (e.g., Chart.js) to display time allocation by group and activity.
+\[x] Task DB-03: Use a charting library (e.g., Chart.js) to display time allocation by group and activity.
 
 
 

--- a/config/mock_activity_logs.json
+++ b/config/mock_activity_logs.json
@@ -1,0 +1,22 @@
+[
+  {"group_id": "finance", "activity": "Administration", "sub_activity": "Budget & Financial Management"},
+  {"group_id": "finance", "activity": "Administration", "sub_activity": "Budget & Financial Management"},
+  {"group_id": "finance", "activity": "Meeting", "sub_activity": "Internal Team Meetings"},
+  {"group_id": "finance", "activity": "Meeting", "sub_activity": "Internal Team Meetings"},
+  {"group_id": "it", "activity": "Development", "sub_activity": "IT Systems Support & Development"},
+  {"group_id": "it", "activity": "Development", "sub_activity": "IT Systems Support & Development"},
+  {"group_id": "it", "activity": "Administration", "sub_activity": "Training & Professional Development"},
+  {"group_id": "qa", "activity": "Project Management", "sub_activity": "Clinical Site Management"},
+  {"group_id": "qa", "activity": "Project Management", "sub_activity": "Patient Recruitment & Screening"},
+  {"group_id": "qa", "activity": "Meeting", "sub_activity": "External Partner/Sponsor Meetings"},
+  {"group_id": "ctti", "activity": "Research", "sub_activity": "Writing & Manuscript Preparation"},
+  {"group_id": "ctti", "activity": "Research", "sub_activity": "Grant Writing & Submission"},
+  {"group_id": "ctti", "activity": "Analysis", "sub_activity": "Statistical Analysis & Reporting"},
+  {"group_id": "imaging", "activity": "Project Management", "sub_activity": "Regulatory Submissions & Compliance"},
+  {"group_id": "imaging", "activity": "Project Management", "sub_activity": "Data Collection & Entry"},
+  {"group_id": "imaging", "activity": "Meeting", "sub_activity": "External Partner/Sponsor Meetings"},
+  {"group_id": "imaging", "activity": "Analysis", "sub_activity": "Statistical Analysis & Reporting"},
+  {"group_id": "imaging", "activity": "Other", "sub_activity": ""},
+  {"group_id": "data_solutions", "activity": "Analysis", "sub_activity": "Statistical Analysis & Reporting"},
+  {"group_id": "data_solutions", "activity": "Administration", "sub_activity": "Administrative Tasks (Email, Scheduling)"}
+]

--- a/src/time_profiler/seed_mock_data.py
+++ b/src/time_profiler/seed_mock_data.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+from . import create_app, SessionLocal, models
+
+
+def seed_from_file(data_path: Path, db_url: str | None = None) -> None:
+    """Seed the database with mock ActivityLog entries."""
+    app_config = {}
+    if db_url:
+        app_config["DATABASE_URL"] = db_url
+    app = create_app(app_config)
+
+    with data_path.open("r", encoding="utf-8") as f:
+        entries = json.load(f)
+
+    session = SessionLocal()
+    try:
+        for item in entries:
+            log = models.ActivityLog(
+                group_id=item["group_id"],
+                activity=item["activity"],
+                sub_activity=item["sub_activity"],
+            )
+            session.add(log)
+        session.commit()
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Seed mock activity log data")
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=Path(__file__).resolve().parents[2]
+        / "config"
+        / "mock_activity_logs.json",
+        help="Path to JSON file with mock data",
+    )
+    parser.add_argument(
+        "--db-url",
+        type=str,
+        default="sqlite:///dcri_logger.db",
+        help="Database URL",
+    )
+    args = parser.parse_args()
+
+    seed_from_file(args.data, args.db_url)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DCRI Activity Dashboard</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <style>
         body { padding: 2rem; }
     </style>
@@ -26,12 +27,52 @@
                 if (!response.ok) {
                     throw new Error("Failed to load results");
                 }
-                // Store results globally for later chart rendering (DB-03)
-                window.dashboardData = await response.json();
-                console.log("Aggregated results", window.dashboardData);
+                const data = await response.json();
+                window.dashboardData = data;
+                console.log("Aggregated results", data);
 
-                // For now, simply show the raw JSON as a placeholder
-                container.innerHTML = `<pre>${JSON.stringify(window.dashboardData, null, 2)}</pre>`;
+                // Aggregate counts by group and activity
+                const groupTotals = {};
+                const activityTotals = {};
+                data.forEach((row) => {
+                    groupTotals[row.group_id] = (groupTotals[row.group_id] || 0) + row.count;
+                    activityTotals[row.activity] = (activityTotals[row.activity] || 0) + row.count;
+                });
+
+                container.innerHTML = "";
+                const groupCanvas = document.createElement("canvas");
+                container.appendChild(groupCanvas);
+                new Chart(groupCanvas.getContext("2d"), {
+                    type: "bar",
+                    data: {
+                        labels: Object.keys(groupTotals),
+                        datasets: [
+                            {
+                                label: "Time by Group",
+                                data: Object.values(groupTotals),
+                                backgroundColor: "rgba(54, 162, 235, 0.7)",
+                            },
+                        ],
+                    },
+                    options: { responsive: true, plugins: { legend: { display: false } } },
+                });
+
+                const activityCanvas = document.createElement("canvas");
+                container.appendChild(activityCanvas);
+                new Chart(activityCanvas.getContext("2d"), {
+                    type: "bar",
+                    data: {
+                        labels: Object.keys(activityTotals),
+                        datasets: [
+                            {
+                                label: "Time by Activity",
+                                data: Object.values(activityTotals),
+                                backgroundColor: "rgba(75, 192, 192, 0.7)",
+                            },
+                        ],
+                    },
+                    options: { responsive: true, plugins: { legend: { display: false } } },
+                });
             } catch (err) {
                 console.error("Error fetching results:", err);
                 container.textContent = "Error loading results.";


### PR DESCRIPTION
## Summary
- display charts on dashboard page using Chart.js
- add mock data file for sample activity logs
- provide a helper script to seed mock data into the database
- mark DB-03 complete in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687be3e0a6b8832e83db7f00725e49aa