### PR TITLE
Add retention summary feature

### DIFF
--- a/DEVELOPMENT_ROADMAP.md
+++ b/DEVELOPMENT_ROADMAP.md
@@ -18,7 +18,7 @@
 - [✅] CB-01a: Create `UserSubmissionHistory` model to track version/timestamp of each submission
 - [✅] CB-01b: Implement "current state" vs "historical analysis" data queries  
 - [✅] CB-01c: Add archival system for consumed chatbot feedback (mark as processed)
-- [⏳] CB-01d: Create data retention policies (latest submission per user, summarized historical trends) - *Next priority*
+- [✅] CB-01d: Create data retention policies (latest submission per user, summarized historical trends)
 
 ### [✅] Task CB-02: Enhanced Database Models for Chatbot
 **Priority**: Critical Path  

--- a/src/time_profiler/__init__.py
+++ b/src/time_profiler/__init__.py
@@ -4,6 +4,7 @@ from .app import create_app, init_db, SessionLocal, Base
 from .models import ActivityLog
 from .ai_insights import ProblemAggregator
 from .data_migration import migrate_activity_logs_to_time_allocations
+from .data_retention import run_retention_tasks
 
 __all__ = [
     "create_app",
@@ -13,4 +14,5 @@ __all__ = [
     "ActivityLog",
     "ProblemAggregator",
     "migrate_activity_logs_to_time_allocations",
+    "run_retention_tasks",
 ]

--- a/src/time_profiler/app.py
+++ b/src/time_profiler/app.py
@@ -770,4 +770,12 @@ def create_app(config_object: dict | None = None) -> Flask:
         finally:
             session.close()
 
+    @app.cli.command("run-retention")
+    def run_retention_cli() -> None:
+        """Run data retention cleanup tasks."""
+        from .data_retention import run_retention_tasks
+
+        run_retention_tasks()
+        print("Retention tasks completed")
+
     return app

--- a/src/time_profiler/data_retention.py
+++ b/src/time_profiler/data_retention.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Utilities for data retention and summarization."""
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict
+
+from .app import SessionLocal
+from . import models
+
+
+def summarize_entries(entries: list[models.UserSubmissionHistory]) -> Dict:
+    """Return a summarized representation of the given submission entries."""
+    if not entries:
+        return {}
+
+    subtype = entries[0].submission_type
+    if subtype == "time_allocation":
+        totals: Dict[str, float] = defaultdict(float)
+        count = 0
+        for e in entries:
+            activities = e.submission_data.get("activities", {})
+            for act, hrs in activities.items():
+                totals[act] += hrs
+            count += 1
+        if count:
+            return {act: hrs / count for act, hrs in totals.items()}
+    elif subtype == "activity_log":
+        counts: Dict[str, int] = defaultdict(int)
+        for e in entries:
+            act = e.submission_data.get("activity")
+            if act:
+                counts[act] += 1
+        return counts
+    return {"count": len(entries)}
+
+
+def run_retention_tasks() -> None:
+    """Archive old submissions and store summarized history."""
+    session = SessionLocal()
+    now = datetime.utcnow()
+    try:
+        distinct_pairs = (
+            session.query(models.UserSubmissionHistory.user_id,
+                          models.UserSubmissionHistory.submission_type)
+            .distinct()
+            .all()
+        )
+        for user_id, sub_type in distinct_pairs:
+            records = (
+                session.query(models.UserSubmissionHistory)
+                .filter_by(user_id=user_id, submission_type=sub_type)
+                .order_by(models.UserSubmissionHistory.timestamp.desc())
+                .all()
+            )
+            if not records:
+                continue
+            latest = records[0]
+            old = records[1:]
+            if not old:
+                continue
+            summary_data = summarize_entries(old)
+            summary = models.SubmissionSummary(
+                user_id=user_id,
+                submission_type=sub_type,
+                summary_data=summary_data,
+                start_period=min(e.timestamp for e in old),
+                end_period=max(e.timestamp for e in old),
+            )
+            session.add(summary)
+            for rec in old:
+                rec.is_current = False
+                rec.archived_at = now
+        session.commit()
+    finally:
+        session.close()
+

--- a/src/time_profiler/migrations/versions/0005_data_retention.py
+++ b/src/time_profiler/migrations/versions/0005_data_retention.py
@@ -1,0 +1,32 @@
+"""add submission summary table for data retention
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2025-07-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'submission_summary',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.String(), nullable=False),
+        sa.Column('submission_type', sa.String(), nullable=False),
+        sa.Column('summary_data', sa.JSON(), nullable=False),
+        sa.Column('start_period', sa.DateTime(), nullable=False),
+        sa.Column('end_period', sa.DateTime(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('submission_summary')
+

--- a/src/time_profiler/models.py
+++ b/src/time_profiler/models.py
@@ -156,3 +156,23 @@ class JiraTicketLifecycle(Base):
             f"<JiraTicketLifecycle id={self.id} ticket_key={self.ticket_key} "
             f"status={self.status} escalations={self.escalation_count}>"
         )
+
+
+class SubmissionSummary(Base):
+    """Store summarized historical submission data for a user."""
+
+    __tablename__ = "submission_summary"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(String, nullable=False)
+    submission_type = Column(String, nullable=False)
+    summary_data = Column(JSON, nullable=False)
+    start_period = Column(DateTime, nullable=False)
+    end_period = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    def __repr__(self) -> str:
+        return (
+            f"<SubmissionSummary id={self.id} user_id={self.user_id} "
+            f"type={self.submission_type}>"
+        )


### PR DESCRIPTION
## Summary
- implement data retention policies in new module
- create CLI command for cleanup tasks
- add SubmissionSummary model and migration
- update exports and roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d96f82294832eaa7a030970f12d60