### PR TITLE
Integrate Slack Web API

### DIFF
--- a/config/dcri_config.json
+++ b/config/dcri_config.json
@@ -88,4 +88,10 @@
     }
   ],
   "enableFreeTextFeedback": true
+  ,"chatbot": {
+    "slack": {
+      "bot_token": "YOUR_SLACK_BOT_TOKEN",
+      "default_channel": "#general"
+    }
+  }
 }

--- a/config/dcri_config.json.example
+++ b/config/dcri_config.json.example
@@ -88,4 +88,10 @@
     }
   ],
   "enableFreeTextFeedback": true
+  ,"chatbot": {
+    "slack": {
+      "bot_token": "YOUR_SLACK_BOT_TOKEN",
+      "default_channel": "#general"
+    }
+  }
 }

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -14,3 +14,5 @@ def test_get_config_endpoint(tmp_path):
     assert "groups" in data
     assert "activities" in data
     assert "enableFreeTextFeedback" in data
+    assert "chatbot" in data
+    assert "slack" in data["chatbot"]

--- a/tests/test_slack_adapter.py
+++ b/tests/test_slack_adapter.py
@@ -1,0 +1,33 @@
+import asyncio
+from unittest.mock import patch
+
+from time_profiler.chatbot.adapters import SlackAdapter
+from time_profiler.chatbot.base import ChatResponse
+
+
+def test_slack_send_message_success():
+    adapter = SlackAdapter(bot_token="xoxb-test", default_channel="")
+    response = ChatResponse("hi")
+    with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"ok": True}
+        result = asyncio.run(adapter.send_message("U123", response))
+        assert result is True
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://slack.com/api/chat.postMessage"
+        headers = kwargs["headers"]
+        assert headers["Authorization"] == "Bearer xoxb-test"
+        payload = kwargs["json"]
+        assert payload["channel"] == "U123"
+        assert payload["text"] == "hi"
+
+
+def test_slack_send_message_failure():
+    adapter = SlackAdapter(bot_token="xoxb-test", default_channel="")
+    response = ChatResponse("hi")
+    with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"ok": False}
+        result = asyncio.run(adapter.send_message("U123", response))
+        assert result is False
+


### PR DESCRIPTION
## Summary
- implement real Slack API calls in `SlackAdapter.send_message`
- include Slack token config in `dcri_config.json` and example
- test Slack adapter message sending via mocks
- validate config endpoint exposes new Slack settings

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d96fc6ab8832e998ba58d6f38686a