### PR TITLE
Implement TeamsAdapter API calls and config options

### DIFF
--- a/config/dcri_config.json
+++ b/config/dcri_config.json
@@ -87,5 +87,9 @@
       "sub_activities": []
     }
   ],
-  "enableFreeTextFeedback": true
+  "enableFreeTextFeedback": true,
+  "teams": {
+    "app_id": "YOUR_APP_ID",
+    "app_password": "YOUR_APP_PASSWORD"
+  }
 }

--- a/config/dcri_config.json.example
+++ b/config/dcri_config.json.example
@@ -87,5 +87,9 @@
       "sub_activities": []
     }
   ],
-  "enableFreeTextFeedback": true
+  "enableFreeTextFeedback": true,
+  "teams": {
+    "app_id": "YOUR_APP_ID",
+    "app_password": "YOUR_APP_PASSWORD"
+  }
 }

--- a/src/time_profiler/chatbot/adapters.py
+++ b/src/time_profiler/chatbot/adapters.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from typing import Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timedelta
+from pathlib import Path
+import os
+import json
+import requests
 
 from .base import ChatbotPlatformAdapter, ChatMessage, ChatResponse
 
@@ -37,21 +41,61 @@ class WebChatAdapter(ChatbotPlatformAdapter):
 
 class TeamsAdapter(ChatbotPlatformAdapter):
     """Adapter for Microsoft Teams integration."""
-    
+
+    def __init__(self, app_id: Optional[str] = None, app_password: Optional[str] = None):
+        config = {}
+        try:
+            cfg_path = Path(__file__).resolve().parents[2] / "config" / "dcri_config.json"
+            with cfg_path.open("r", encoding="utf-8") as f:
+                config = json.load(f)
+        except Exception:
+            pass
+
+        teams_cfg = config.get("teams", {}) if isinstance(config, dict) else {}
+        self.app_id = app_id or os.getenv("TEAMS_APP_ID") or teams_cfg.get("app_id")
+        self.app_password = (
+            app_password or os.getenv("TEAMS_APP_PASSWORD") or teams_cfg.get("app_password")
+        )
+        self._access_token: Optional[str] = None
+        self._token_expiry: datetime = datetime.utcnow()
+        self._conversations: Dict[str, Dict[str, str]] = {}
+
     async def send_message(self, user_id: str, response: ChatResponse) -> bool:
         """Send message to Teams user."""
-        # TODO: Implement Teams Bot Framework integration
-        # This would use the Bot Framework SDK to send messages
-        print(f"Teams message to {user_id}: {response.text}")
-        return True
-    
+        convo = self._conversations.get(user_id)
+        if not convo:
+            return False
+
+        token = self._get_access_token()
+        if not token:
+            return False
+
+        url = f"{convo['service_url']}/v3/conversations/{convo['conversation_id']}/activities"
+        headers = {"Authorization": f"Bearer {token}"}
+        payload = {"type": "message", "text": response.text}
+
+        try:
+            resp = requests.post(url, headers=headers, json=payload, timeout=5)
+            return 200 <= resp.status_code < 300
+        except Exception:
+            return False
+
     async def parse_message(self, raw_message: Dict[str, Any]) -> ChatMessage:
         """Parse Teams activity format."""
         # Teams Bot Framework activity structure
         activity = raw_message
-        
+
+        user_id = activity.get("from", {}).get("id", "unknown")
+        conv_id = activity.get("conversation", {}).get("id")
+        service_url = activity.get("serviceUrl")
+        if user_id and conv_id and service_url:
+            self._conversations[user_id] = {
+                "conversation_id": conv_id,
+                "service_url": service_url,
+            }
+
         return ChatMessage(
-            user_id=activity.get("from", {}).get("id", "unknown"),
+            user_id=user_id,
             text=activity.get("text", ""),
             timestamp=datetime.fromisoformat(activity.get("timestamp", datetime.utcnow().isoformat())),
             platform="teams",
@@ -61,6 +105,34 @@ class TeamsAdapter(ChatbotPlatformAdapter):
                 "activity_id": activity.get("id")
             }
         )
+
+    def _get_access_token(self) -> Optional[str]:
+        """Retrieve (and cache) a Bot Framework access token."""
+        if self._access_token and datetime.utcnow() < self._token_expiry:
+            return self._access_token
+
+        if not self.app_id or not self.app_password:
+            return None
+
+        url = "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token"
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": self.app_id,
+            "client_secret": self.app_password,
+            "scope": "https://api.botframework.com/.default",
+        }
+
+        try:
+            resp = requests.post(url, data=data, timeout=5)
+            resp.raise_for_status()
+            payload = resp.json()
+            self._access_token = payload.get("access_token")
+            expires = int(payload.get("expires_in", 3600))
+            self._token_expiry = datetime.utcnow() + timedelta(seconds=expires - 60)
+        except Exception:
+            self._access_token = None
+
+        return self._access_token
     
     async def authenticate_user(self, raw_message: Dict[str, Any]) -> Optional[str]:
         """Authenticate Teams user from activity."""

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -14,3 +14,5 @@ def test_get_config_endpoint(tmp_path):
     assert "groups" in data
     assert "activities" in data
     assert "enableFreeTextFeedback" in data
+    assert "teams" in data
+    assert "app_id" in data["teams"]

--- a/tests/test_teams_adapter.py
+++ b/tests/test_teams_adapter.py
@@ -1,0 +1,45 @@
+import asyncio
+from unittest.mock import patch
+from time_profiler.chatbot.adapters import TeamsAdapter, ChatResponse
+
+
+def test_send_message_calls_api(monkeypatch):
+    adapter = TeamsAdapter(app_id="id", app_password="pw")
+    adapter._conversations["u1"] = {
+        "conversation_id": "conv",
+        "service_url": "https://service"
+    }
+
+    token_payload = {"access_token": "tok", "expires_in": 3600}
+
+    calls = {}
+
+    def fake_post(url, *args, **kwargs):
+        if url.startswith("https://login.microsoftonline.com"):
+            calls["token"] = True
+            class Resp:
+                status_code = 200
+                def json(self):
+                    return token_payload
+                def raise_for_status(self):
+                    pass
+            return Resp()
+        else:
+            calls["message"] = {
+                "url": url,
+                "headers": kwargs.get("headers"),
+                "json": kwargs.get("json")
+            }
+            class Resp:
+                status_code = 200
+            return Resp()
+
+    monkeypatch.setattr("time_profiler.chatbot.adapters.requests.post", fake_post)
+
+    result = asyncio.run(adapter.send_message("u1", ChatResponse("hi")))
+
+    assert result is True
+    assert "token" in calls
+    assert "message" in calls
+    assert calls["message"]["json"]["text"] == "hi"
+


### PR DESCRIPTION
## Summary
- implement TeamsAdapter using Bot Framework REST API
- store conversation references on incoming Teams messages
- add OAuth token retrieval for Teams adapter
- expose Teams credentials in `dcri_config.json` and example config
- update config endpoint tests and add new Teams adapter test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d96fa92f4832eae2ee3ca08dda082