### PR TITLE
Implement Slack adapter configuration

### DIFF
--- a/src/time_profiler/chatbot/adapters.py
+++ b/src/time_profiler/chatbot/adapters.py
@@ -76,6 +76,7 @@ class SlackAdapter(ChatbotPlatformAdapter):
     """Adapter for Slack integration."""
 
     def __init__(self, bot_token: str | None = None, default_channel: str | None = None) -> None:
+        """Initialize Slack adapter from environment settings."""
         self.bot_token = bot_token or os.getenv("SLACK_BOT_TOKEN")
         if default_channel is not None:
             self.default_channel = default_channel


### PR DESCRIPTION
## Summary
- document environment-based initialization for `SlackAdapter`
- ensure Slack bot configuration is read from environment variables

## Testing
- `pytest tests/test_slack_adapter.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687da036b228832ebbf3e75f9102e029