### PR TITLE
Add Slack adapter unit tests

### DIFF
--- a/tests/test_slack_adapter.py
+++ b/tests/test_slack_adapter.py
@@ -30,4 +30,3 @@ def test_slack_send_message_failure():
         mock_post.return_value.json.return_value = {"ok": False}
         result = asyncio.run(adapter.send_message("U123", response))
         assert result is False
-


### PR DESCRIPTION
## Summary
- create a dedicated `tests/test_slack_adapter.py`
- include tests for successful and failed message posting using `unittest.mock.patch`

## Testing
- `pytest tests/test_slack_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_b_687da037fb54832e83d9521fb01a5ae7