### PR TITLE
Add Teams config and extend config endpoint test

### DIFF
--- a/config/dcri_config.json
+++ b/config/dcri_config.json
@@ -93,5 +93,9 @@
       "bot_token": "YOUR_SLACK_BOT_TOKEN",
       "default_channel": "#general"
     }
+  },
+  "teams": {
+    "app_id": "YOUR_TEAMS_APP_ID"
   }
 }
+

--- a/config/dcri_config.json.example
+++ b/config/dcri_config.json.example
@@ -93,5 +93,9 @@
       "bot_token": "YOUR_SLACK_BOT_TOKEN",
       "default_channel": "#general"
     }
+  },
+  "teams": {
+    "app_id": "YOUR_TEAMS_APP_ID"
   }
 }
+

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -14,5 +14,7 @@ def test_get_config_endpoint(tmp_path):
     assert "groups" in data
     assert "activities" in data
     assert "enableFreeTextFeedback" in data
+    assert "teams" in data
+    assert "app_id" in data["teams"]
     assert "chatbot" in data
     assert "slack" in data["chatbot"]


### PR DESCRIPTION
## Summary
- extend API config test to check for Teams settings
- expose Teams application ID in `dcri_config.json` and example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687da03952b8832e870cb94f2c431da0